### PR TITLE
add option nginx_clientcert_verify to require client-cert-verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Configure nginx for general use. TLS is always enabled per default enforced (in 
 |nginx_fullchain_path|(see `defaults/main.yml`)|Path to the certificate bundle used to verify an OCSP server's response|
 |nginx_extra_hosts|`[]`| List of extra vhosts to create. They work just like the base vhost, see `defaults/main.yml` for how to format the list|
 |nginx_proxy_subnet|`192.168.0.0/24`|Subnet to trust with origin IP when using the proxy protocol|
-|nginx_clientcert|unset| Path to a valid CA cert for client certificates. Client certificates will be requested but not required. Mutually exclusive with OCSP stapling at the moment. |
+|nginx_clientcert|unset| Path to a valid CA cert for client certificates. If `nginx_clientcert_verify` is unset, client certificates will be requested but not required. Mutually exclusive with OCSP stapling at the moment. |
+|nginx_clientcert_verify|unset|If `nginx_clientcert` is used, set verification. Available options: `"on"`, `"off"`, `"optional"`, `"optional_no_ca"`. Defaults to `"optional"`. |
 |nginx_enable_spnego|`False`| Whether to enable SPNEGO (Kerberos) support|
 |nginx_spnego_realm|`EXAMPLE.ORG`| Which kerberos realm to use|
 |nginx_spenego_users|`[]`| If set, which users to limit auth to|

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -91,7 +91,7 @@ server {
 {% if nginx_clientcert is defined %}
     ssl_client_certificate {{ nginx_clientcert }};
     ssl_trusted_certificate {{ nginx_clientcert }};
-    ssl_verify_client optional;
+    ssl_verify_client {% if nginx_clientcert_verify is not defined %}optional{% else %}{{ nginx_clientcert_verify }}{% endif %};
     ssl_verify_depth 1;
 
 {% endif %}


### PR DESCRIPTION
This MR adds the option `nginx_clientcert_verify` to configure whether client-certs should be verified.

https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_verify_client